### PR TITLE
1375 r2base patch

### DIFF
--- a/setupLab1375.sh
+++ b/setupLab1375.sh
@@ -173,7 +173,7 @@ done
 ans=""
 ans1="ANS1"
 until [ "$ans" == "$ans1" ]; do
-  printf "Client ID is in the form of UUID            : 12345678-1234-1234-1234-123456789012"
+  printf "Client ID is in the form of UUID            : 12345678-1234-1234-1234-123456789012\n"
   printf "Enter Client ID for the BlueCompute-$suffix :"
   read ans
   printf "Confirm the client ID                       :"
@@ -195,18 +195,33 @@ git clone -b r2base https://github.com/ibm-cloud-architecture/refarch-cloudnativ
 git clone -b r2base https://github.com/ibm-cloud-architecture/refarch-cloudnative-api
 git clone -b r2base https://github.com/ibm-cloud-architecture/refarch-cloudnative-bluecompute-web
 
-#cd /home/bmxuser/refarch-cloudnative-api 
-#git checkout 555d5cc380af08876b0aa65c22d357ee4806d645
-#cd /home/bmxuser/refarch-cloudnative-bluecompute-web 
-#git checkout 1c0d0bc8aee0bfdce8e0f3381acb39274c1e4ef3
+#cd /home/bmxuser/refarch-cloudnative-api
+#git checkout 713ff236c7184f5a26987e27a6d0091ab1314ed9
+#cd /home/bmxuser/refarch-cloudnative-bluecompute-web
+#git checkout 8396d824665968e1040e423308b7e8e378f62280
 
 apic login -s $apicreg.apiconnect.ibmcloud.com -u $userid -p $password
 sleep 20
-catexist=`apic catalogs -s $apicreg.apiconnect.ibmcloud.com -o $suffix-$spctxt | grep bluecompute-$suffix | wc -l`
+
+#apic orgs may return multiple. retrieve list & search each for the bluecompute- catalogue
+apicorglist=`apic orgs -s $apicreg.apiconnect.ibmcloud.com | grep $suffix`
+
+for apicorg in $apicorglist; do
+   catexist=`apic catalogs -s $apicreg.apiconnect.ibmcloud.com -o $apicorg | grep bluecompute-$suffix | wc -l`
+   if [ $catexist -eq 1 ]; then
+	break
+   fi
+done
+
 until [ $catexist -eq 1 ]; do
-   echo "Cannot get the unique catalog bluecompute-$suffix. Please create the catalog ..."
+   echo "Cannot get the unique catalog bluecompute-$suffix. Please create the catalog, then press ENTER ..."
    read ans
-   catexist=`apic catalogs -s $apicreg.apiconnect.ibmcloud.com -o $suffix-$spctxt | grep bluecompute-$suffix | wc -l`
+   for apicorg in $apicorglist; do
+      catexist=`apic catalogs -s $apicreg.apiconnect.ibmcloud.com -o $apicorg | grep bluecompute-$suffix | wc -l`
+      if [ $catexist -eq 1 ]; then
+	break
+      fi
+   done
 done
 
 echo "#######################################################################"
@@ -228,13 +243,13 @@ cd /home/bmxuser/refarch-cloudnative-bff-socialreview/socialreview
 
 apic login -s $apicreg.apiconnect.ibmcloud.com -u $userid -p $password
 sleep 20
-apic config:set app=apic-app://$apicreg.apiconnect.ibmcloud.com/orgs/$suffix-$spctxt/apps/socialreview-bff-app-$suffix
+apic config:set app=apic-app://$apicreg.apiconnect.ibmcloud.com/orgs/$apicorg/apps/socialreview-bff-app-$suffix
 sleep 20
 apic apps:publish
-# sleep 20
-# cf bs socialreview-bff-app-$suffix cloudnative-autoscale-$suffix
-# sleep 20
-# cf restage socialreview-bff-app-$suffix
+sleep 20
+cf bs socialreview-bff-app-$suffix cloudnative-autoscale-$suffix
+sleep 20
+cf restage socialreview-bff-app-$suffix
 sleep 20
 
 sochost=`cf apps | grep socialreview-bff | awk '{ print $6;}'`
@@ -252,20 +267,30 @@ echo "#######################################################################"
 echo "# 5 Update API definitions and publish APIs"
 
 sed -i -e 's/inventory-bff-app.mybluemix.net/inventory-bff-app-'$suffix.$domreg$dom'/g' /home/bmxuser/refarch-cloudnative-api/inventory/inventory.yaml
-sed -i -e 's/api.us.apiconnect.ibmcloud.com\/centusibmcom-cloudnative-dev\/bluecompute/api.'$apicreg'.apiconnect.ibmcloud.com\/'$suffix'-'$spctxt'\/bluecompute-'$suffix'/g' /home/bmxuser/refarch-cloudnative-bff-socialreview/socialreview/definitions/socialreview.yaml
+sed -i -e 's/api.us.apiconnect.ibmcloud.com\/centusibmcom-cloudnative-dev\/bluecompute/api.'$apicreg'.apiconnect.ibmcloud.com\/'$apicorg'\/bluecompute-'$suffix'/g' /home/bmxuser/refarch-cloudnative-bff-socialreview/socialreview/definitions/socialreview.yaml
 sed -i -e 's/apiconnect-243ab119-1c05-402c-a74c-6125122c9273.centusibmcom-cloudnative-dev.apic.mybluemix.net/'$sochost'/g' /home/bmxuser/refarch-cloudnative-bff-socialreview/socialreview/definitions/socialreview.yaml
 
 cd /home/bmxuser/refarch-cloudnative-api/inventory/
-apic config:set catalog=apic-catalog://$apicreg.apiconnect.ibmcloud.com/orgs/$suffix-$spctxt/catalogs/bluecompute-$suffix
-sleep 10
-apic publish inventory-product_0.0.1.yaml
-sleep 20
+apic config:set catalog=apic-catalog://$apicreg.apiconnect.ibmcloud.com/orgs/$apicorg/catalogs/bluecompute-$suffix
+
+publishDone=`apic publish inventory-product_0.0.1.yaml | grep "Published " | wc -l`
+until [  $publishDone -eq 1 ]; do
+    sleep 10         
+    publishDone=`apic publish inventory-product_0.0.1.yaml | grep "Published " | wc -l`
+    sleep 10
+done  
 
 cd /home/bmxuser/refarch-cloudnative-bff-socialreview/socialreview/definitions/
-apic config:set catalog=apic-catalog://$apicreg`.apiconnect.ibmcloud.com/orgs/$suffix-$spctxt/catalogs/bluecompute-$suffix
+apic config:set catalog=apic-catalog://$apicreg.apiconnect.ibmcloud.com/orgs/$apicorg/catalogs/bluecompute-$suffix
 sleep 10
-apic publish socialreview-product.yaml
-sleep 20
+ans="0"
+
+publishDone=`apic publish socialreview-product.yaml | grep "Published " | wc -l`
+until [  $publishDone -eq 1 ]; do
+    sleep 10         
+    publishDone=`apic publish socialreview-product.yaml | grep "Published " | wc -l`
+    sleep 10
+done  
 
 echo "#######################################################################"
 echo "# 6 prepare Web application"
@@ -275,7 +300,7 @@ sed -i -e 's/mybluemix.net/'$domreg$dom'/g' manifest.yml
 sed -i -e 's/bluecompute-web-app/bluecompute-web-app-'$suffix'/g' manifest.yml
 
 sed -i -e 's/api.us.apiconnect.ibmcloud.com/api.'$apicreg'.apiconnect.ibmcloud.com/g' config/default.json
-sed -i -e 's/centusibmcom-cloudnative-dev/'$suffix'-'$spctxt'/g' config/default.json
+sed -i -e 's/centusibmcom-cloudnative-dev/'$apicorg'/g' config/default.json
 sed -i -e 's/bluecompute/bluecompute-'$suffix'/g' config/default.json
 
 sed -i -e 's/3f1b4cc8-78dc-450e-9461-edf377105c7a/'$clientID'/g' config/default.json


### PR DESCRIPTION
I've updated all the git calls to use branch r2base (instead of the individual commit ids). I also updated the `apic orgs` & `apic catalogs` calls to handle scenarios where a particular account may have more than one org. (I have multiple apic provider orgs & hit a failure loop around line 205 of the script.)

I've tested this version a few times & it runs cleanly on my system.